### PR TITLE
fixing bug where no message is printed if the watch isn't available -…

### DIFF
--- a/stock.py
+++ b/stock.py
@@ -50,11 +50,10 @@ def check_stock(model, zipcode, dest, sec=5, login=None, pwd=None):
             else:
                 if sname in good_stores:
                     good_stores.remove(sname)
-                    msg = "Oops all {item} in {store} are gone :( ".format(
-                        item=item, store=sname)
-                    print "{0} {1}".format(time.strftime("%m/%d/%Y %H:%M:%S"),
-                                           msg)
-                    my_alert.send(msg)
+                msg = "Oops all {item} in {store} are gone :( ".format(
+                    item=item, store=sname)
+                print "{0} {1}".format(time.strftime("%m/%d/%Y %H:%M:%S"),
+                                       msg)
 
 class Alert(object):
     def __init__(self, dest, login=None, password=None):


### PR DESCRIPTION
… also removed text notification on not available

Removed indentation so the 'no stock' message would show on the console. Additionally, removed the sending of the message through text/email when there is no stock (because presumably this is to be used for showing when there _IS_ stock)
